### PR TITLE
Fixed the clone funtionality for QEMU.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+## Release 0.1.2
+
+**Features**
+
+- Ensured that both `proxmox_api::qemu::create_genericcloud` and `proxmox_api::qemu::clone` are idempotent.
+  - If you now re-run either of them with new VMID values targeting ID's that already exist, they will simply not attempt to overwrite what's already there. This allows the same code to be re-run.
+
+**Bugfixes**
+
+- Fixed and reworked the Clone functionality.
+
+## Release 0.1.1
+
+**Update**
+
+- Added the changelog properly
+- Updated the `metadata.json` file to add requirements.
 
 ## Release 0.1.0 - Initial Commit
 
@@ -13,6 +29,3 @@ All notable changes to this project will be documented in this file.
 
 - n/a
 
-**Known Issues**
-
-- Currently, adding SSH keys doesn't work and should be done manually. Looks to be an issue with how Ruby processes urlencoded strings, but otherwise TBD.

--- a/README.md
+++ b/README.md
@@ -13,12 +13,8 @@ This `proxmox_api` module allows you to simply and programatically control the [
 
 This `proxmox_api` module allows you to perform several functions. Currently, this includes:
 
-1. Create a GenericCloud Cloud-Init enabled image by simply providing some values
+1. Create GenericCloud Cloud-Init enabled image by simply providing some values.
 1. Clone an existing template VM.
-
-## Setup Requirements
-
-`proxmox_api` requires the [puppetlabs/stdlib v6.3.0](https://forge.puppet.com/puppetlabs/stdlib) library or later to your Puppetfile.
 
 ## Usage
 
@@ -82,7 +78,7 @@ Examples for each of the commands are below:
 
 ## Recommendations
 
-I recommend using one of the following URLs for your Generic Cloud Images.
+I'd like to suggest using one of the following URLs for your Generic Cloud Images.
 
 - CentOS 8.2:
   - [CentOS-8-GenericCloud-8.2.2004-20200611.2.x86_64.qcow2](https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.2.2004-20200611.2.x86_64.qcow2)
@@ -95,8 +91,13 @@ I recommend using one of the following URLs for your Generic Cloud Images.
 
 ## Limitations
 
-This is currently being developed and tested against a single [Proxmox 6.2-4](https://pve.proxmox.com/wiki/Roadmap#Proxmox_VE_6.2) node, and is not being actively tested against earlier versions. I cannot promise that things will work as expected if you are running earlier versions of Proxmox.
+- This is currently being developed and tested against a single [Proxmox 6.2-4](https://pve.proxmox.com/wiki/Roadmap#Proxmox_VE_6.2) node, and is not being actively tested against earlier versions. I cannot promise that things will work as expected if you are running earlier versions of Proxmox.
+- This will not (but absolutely could) non-template virtual machines. Reason being is that if you're cloning non-template VM's you're probably approaching your infrastructure wrong.
 
 ## Development
 
 If there are features that this does not perform or if there are bugs you are encountering, [please feel free to open an issue](https://github.com/danmanners/proxmox_api/issues).
+
+# Known Issues
+
+- Currently, adding SSH keys doesn't work and should be done manually. Looks to be an issue with how Ruby processes urlencoded strings, but otherwise TBD.

--- a/manifests/qemu/clone.pp
+++ b/manifests/qemu/clone.pp
@@ -1,26 +1,47 @@
 # Clones an existing Proxmox QEMU VM image.
-# Sets all of the relevant settings through several commands.
+# 
+# This definition creates a QEMU Virtual Machine clone baesd on a template.
+#
+# Paramters:
+#   [*pmx_node*]          - The Proxmox node to create the clone on.
+#   [*clone_id*]          - The ID of the QEMU template to clone.
+#   [*vm_name*]           - The name of the new VM.
+#   [*disk_size*]         - OPTIONAL: The size of the new VM disk. If undefined, the size of the VM template disk will be kept.
+#   [*disk_target]        - OPTIONAL: The storage location for the new VM disk. If undefined, will default to the Templates volume.
+#   [*description*]       - OPTIONAL: The 
+#   [*cpu_sockets*]       - The number of CPU sockets to be assigned to the new VM.
+#   [*cpu_cores*]         - The number of CPU cores to be assigned to the new VM.
+#   [*memory*]            - The amount of memory to be assigned to the new VM, in Megabytes (2GB = 2048).
+#   [*protected*]         - OPTIONAL: If true, it will protect the new VM from accidental deletion.
+#   [*ipv4_static]        - Boolean. If true, you must define the CIDR and Gateway values.
+#   [*ipv4_static_cidr*]  - OPTIONAL: If ipv4_static is true, this value must be in the format '192.168.1.20/24'.
+#   [*ipv4_static_gw*]    - OPTIONAL: If ipv4_static is true, this value must be in the format '192.168.1.1'.
+#   [*ci_username*]       - OPTIONAL: The default username for the Cloud-Init drive to be configured.
+#   [*ci_password*]       - OPTIONAL: The default password for the Cloud-Init drive to be configured.
+#   [*newid*]             - OPTIONAL: The ID for the new Virtual Machine. If unassigned, the next available ID will be used.
+#   [*clone_type*]        - Boolean. If true, a full disk clone will be created. If false, a linked-clone will be created. Not recommended.
+#
 define proxmox_api::qemu::clone (
   # Clone Settings
-  String[1]         $node,
+  String[1]         $pmx_node,
   Integer[1]        $clone_id,
   String[1]         $vm_name,
-  Integer           $newid            = Integer($facts['proxmox_cluster_nextid']),
-  Boolean           $clone_type       = true,
-  Optional[String]  $description      = Undef,
-  Optional[String]  $disk_target      = Undef,
+  String            $disk_size,
+  Optional[String]  $disk_target  = undef,
+  Optional[String]  $description  = undef,
+  Integer           $newid         = Integer($facts['proxmox_cluster_nextid']),
   # VM Settings
-  Integer     $disk_size              = 8, # Make sure you only use whole numbers larger than 8; this is multiplied by 1024.
-  Integer     $cpu_sockets            = 1,
-  Integer     $cpu_cores              = 1,
-  Integer     $memory                 = 2048,
-  Boolean     $protected              = false,
-  # Cloud-Init Values
-  Optional[Boolean] $ipv4_static      = false,
-  Optional[String]  $ipv4_static_cidr = Undef, # Needs to be in the format '192.168.1.20/24'
-  Optional[String]  $ipv4_static_gw   = Undef, # Needs to be in the format '192.168.1.1'
-  Optional[String]  $ci_username      = Undef,
-  Optional[String]  $ci_password      = Undef,
+  Integer           $cpu_sockets  = 1,
+  Integer           $cpu_cores    = 1,
+  Integer           $memory       = 2048,
+  Boolean           $protected    = false,
+  Boolean           $clone_type    = true,
+  # Network & Cloud-Init Settings
+  Optional[Boolean] $ipv4_static  = false,
+  Optional[String]  $ipv4_static_cidr = undef, # Needs to be in the format '192.168.1.20/24'
+  Optional[String]  $ipv4_static_gw = undef, # Needs to be in the format '192.168.1.1'
+  Optional[String]  $ci_username,
+  Optional[String]  $ci_password,
   # String      $ci_sshkey        = '', # Commented out; difficulties below.
 ) {
 
@@ -41,98 +62,106 @@ define proxmox_api::qemu::clone (
   }
   # Generate a list of all storage mediums on the specified node
   $disk_targets = $proxmox_storage.map|$hash|{
-    if $hash['node'] == $node {
+    if $hash['node'] == $pmx_node {
       $hash['storage']
     }
   }
 
   # Evaluate variables to make sure we're safe to continue.
+  # Confirm that the Clone ID is not the same as the New ID.
   if $clone_id != $newid {
-    if $newid in $vmids {
-      # Error out
-      fail('clone_id already exists!')
-    }
+    # If the Clone ID is not in the list of Templates, error out.
     if ! ($clone_id in $templates) {
-      # Error out
       fail('clone_id does not appear to exist.')
     }
+    # If the Clone ID is the same as the New ID, error out.
   } elsif $clone_id == $newid {
-    # Error Out
     fail('The clone_id and newid values cannot match.')
   }
 
-  # Evaluate if there's a Description string.
-  if $description != '' {
-    $if_description = "--description='${description}'"
-  }
+  # Confirm that the New ID is not in the list of existing VMIDs.
+  # If the New ID is in the list, simply don't attempt to create/overwrite it.
+  if ! ($newid in $vmids) {
+    # Evaluate if there's a Description string.
+    if $description {
+      $if_description = "--description='${description}'"
+    }
 
-  # Evaluate if there's a Disk Target String.
-  if $disk_target != '' {
-    if $disk_target in $disk_targets {
-      $if_disk_target = "--target='${disk_target}'"
+    # Evaluate if there's a Disk Target String.
+    if $disk_target {
+      if $disk_target in $disk_targets {
+        $if_disk_target = "--storage='${disk_target}'"
+      } else {
+        fail('The disk target cannot be found.')
+      }
     } else {
-      fail('The disk target cannot be found.')
+      $if_disk_target = ''
     }
-  }
 
-  # Evaluate if the VM should be protected
-  if ($protected == true) {
-    $if_protection = '--protection 1'
-  }
-
-  # Evaluate if there's a Clone Type Boolean
-  if ($clone_type == true) {
-    $if_clone_type = '--full 1'
-  }
-
-  # Check if there's a custom Cloud-Init User
-  if ($ci_username != '') {
-    $if_ciuser = "--ciuser=${ci_username}"
-  }
-
-  # Check if there's a custom Cloud-Init Password
-  if ($ci_password != '') {
-    $if_cipassword = "--cipassword='${ci_username}'"
-  }
-
-  # Check if there's a custom Cloud-Init SSH Key, and URI encodes it
-  # Commented out, having immense difficulty figuring out the correct string format.
-  # if ($ci_sshkey != '') {
-  #   $uriencodedsshkey = uriescape($ci_sshkey)
-  #   $if_cisshkey = "--sshkeys=${uriencodedsshkey}"
-  # }
-
-  # Check if there are custom Cloud-Init network requirements
-  if ($ipv4_static == true) {
-    if (($ipv4_static_cidr =~ Stdlib::IP::Address::V4) == false) and ($ipv4_static_cidr != '') {
-      fail('IP address is in the wrong format or undefined.')
+    # Evaluate if the VM should be protected
+    if ($protected == true) {
+      $if_protection = '--protection 1'
+    } else {
+      $if_protection = ''
     }
-    if (($ipv4_static_gw =~ Stdlib::IP::Address::V4) == false) and ($ipv4_static_gw != '') {
-      fail('Gateway address is in the wrong format or undefined.')
+
+    # Evaluate if there's a Clone Type Boolean
+    if ($clone_type == true) {
+      $if_clone_type = '--full 1'
     }
-    # If the above checks pass, set the ip settings
-    $if_nondhcp = "--ipconfig0='ip=${ipv4_static_cidr},gw=${ipv4_static_gw}'"
-  }
 
-  # Create the VM
-  exec{"clone_${clone_id}_to_${newid}":
-    command => "/usr/bin/pvesh create /nodes/${$node}/qemu/${clone_id}/clone --newid=${newid} \
-    --name=${vm_name} ${if_description} ${if_disk_target} ${if_clone_type}",
-  }
+    # Check if there's a custom Cloud-Init User
+    if ($ci_username != '') {
+      $if_ciuser = "--ciuser=${ci_username}"
+    }
 
-  # Set the disk size
-  $final_disk_size = $disk_size * 1024
-  exec{"set_disk_size_${newid}":
-    command => "/usr/bin/pvesh set /nodes/${node}/qemu/${newid}/resize \
-    -disk=scsi0 --size=${final_disk_size}M",
-    require => Exec["clone_${clone_id}_to_${newid}"],
-  }
+    # Check if there's a custom Cloud-Init Password
+    if ($ci_password != '') {
+      $if_cipassword = "--cipassword='${ci_username}'"
+    }
 
-  # Set the Cloud-Init Values
-  exec{"set_qemu_values_${newid}":
-    command => "/usr/bin/pvesh set /nodes/${node}/qemu/${newid}/config \
-    --sockets=${cpu_sockets} --cores=${cpu_cores} --memory=${memory} ${if_protection} \
-    ${if_ciuser} ${if_cipassword} ${if_nondhcp}",
-    require => Exec["set_disk_size_${newid}"],
+    # Check if there's a custom Cloud-Init SSH Key, and URI encodes it
+    # Commented out, having immense difficulty figuring out the correct string format.
+    # if ($ci_sshkey != '') {
+    #   $uriencodedsshkey = uriescape($ci_sshkey)
+    #   $if_cisshkey = "--sshkeys=${uriencodedsshkey}"
+    # }
+
+    # Check if there are custom Cloud-Init network requirements
+    if $ipv4_static == true {
+      if (($ipv4_static_cidr =~ Stdlib::IP::Address::V4) == false) and ($ipv4_static_cidr != '') {
+        fail('IP address is in the wrong format or undefined.')
+      }
+      if (($ipv4_static_gw =~ Stdlib::IP::Address::V4) == false) and ($ipv4_static_gw != '') {
+        fail('Gateway address is in the wrong format or undefined.')
+      }
+      # If the above checks pass, set the ip settings
+      $if_nondhcp = "--ipconfig0='ip=${ipv4_static_cidr},gw=${ipv4_static_gw}'"
+    } else {
+      $if_nondhcp = ''
+    }
+
+    # Create the VM
+    exec{"clone_${clone_id}_to_${newid}":
+      command => "/usr/bin/pvesh create /nodes/${pmx_node}/qemu/${clone_id}/clone --newid=${newid} \
+      --name=${vm_name} ${if_description} ${if_disk_target} ${if_clone_type}",
+    }
+
+    # Set the disk size
+    if $disk_size {
+      exec{"set_disk_size_${newid}":
+        command => "/usr/bin/pvesh set /nodes/${pmx_node}/qemu/${newid}/resize \
+        -disk=scsi0 --size=${disk_size}",
+        require => Exec["clone_${clone_id}_to_${newid}"],
+      }
+    }
+
+    # Set the Cloud-Init Values
+    exec{"set_qemu_values_${newid}":
+      command => "/usr/bin/pvesh set /nodes/${pmx_node}/qemu/${newid}/config \
+      --sockets=${cpu_sockets} --cores=${cpu_cores} --memory=${memory} \
+      ${if_protection} ${if_ciuser} ${if_cipassword} ${if_nondhcp}",
+      require => Exec["set_disk_size_${newid}"],
+    }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "danmanners-proxmox_api",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": "Dan Manners",
   "summary": "Allows simple and programatic control over the Proxmox Hypervisor.",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Release 0.1.2

**Features**

- Ensured that both `proxmox_api::qemu::create_genericcloud` and `proxmox_api::qemu::clone` are idempotent.
  - If you now re-run either of them with new VMID values targeting ID's that already exist, they will simply not attempt to overwrite what's already there. This allows the same code to be re-run.

**Bugfixes**

- Fixed and reworked the Clone functionality.